### PR TITLE
Feat/certs route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+*.log
 
 ### STS ###
 .apt_generated

--- a/src/main/kotlin/com/pucrs/construcaosoftware/ConstrucaoSoftwareApplication.kt
+++ b/src/main/kotlin/com/pucrs/construcaosoftware/ConstrucaoSoftwareApplication.kt
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-@OpenAPIDefinition(info = Info(title = "API", version = "1.0", description = "vamo ve essa coisa"))
+@OpenAPIDefinition(info = Info(title = "Keyseguro", version = "1.0.3", description = "API de autenticação e gerenciamento de usuários"))
 class ConstrucaoSoftwareApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/pucrs/construcaosoftware/ConstrucaoSoftwareApplication.kt
+++ b/src/main/kotlin/com/pucrs/construcaosoftware/ConstrucaoSoftwareApplication.kt
@@ -6,7 +6,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-@OpenAPIDefinition(info = Info(title = "Keyseguro", version = "1.0.3", description = "API de autenticação e gerenciamento de usuários"))
+@OpenAPIDefinition(info = Info(title = "Keyseguro", version = "1.0.4", description = "API de autenticação e gerenciamento de usuários"))
 class ConstrucaoSoftwareApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/pucrs/construcaosoftware/api/AuthController.kt
+++ b/src/main/kotlin/com/pucrs/construcaosoftware/api/AuthController.kt
@@ -3,7 +3,9 @@ package com.pucrs.construcaosoftware.api
 import com.pucrs.construcaosoftware.dto.LoginDTO
 import com.pucrs.construcaosoftware.dto.TokenDTO
 import com.pucrs.construcaosoftware.dto.RefreshTokenDTO
+import com.pucrs.construcaosoftware.dto.EvaluatePermissionDTO
 import com.pucrs.construcaosoftware.keycloak.KeycloakClient
+import com.pucrs.construcaosoftware.exceptions.InvalidDataException
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.bind.annotation.RequestMethod
@@ -23,6 +25,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.parameters.RequestBody
 import org.springframework.http.MediaType
+import kotlin.collections.mapOf
 
 @Configuration
 class AuthController {
@@ -76,6 +79,25 @@ class AuthController {
                 summary = "Recupera as chaves públicas do servidor, no formato JWK, para validação dos tokens",
             ),
         ),
+        RouterOperation(
+            path = "/auth/evaluate_permission",
+            method = arrayOf(RequestMethod.POST),
+            beanClass = AuthHandler::class,
+            beanMethod = "evaluatePermission",
+            operation = Operation(
+                operationId = "evaluatePermission",
+                method = "POST",
+                summary = "Verifica se o usuário tem permissão para acessar determinada rota",
+                requestBody = RequestBody(
+                    required = true,
+                    content = arrayOf(
+                        Content(
+                            schema = Schema(implementation = EvaluatePermissionDTO::class)
+                        )
+                    )
+                )
+            ),
+        )
     )
   @Bean
   fun authRoutes(handler: AuthHandler): RouterFunction<ServerResponse> =
@@ -112,6 +134,22 @@ class AuthController {
                     .bodyValue(e.responseBodyAsString)
             }
         }
+        .andRoute(RequestPredicates.POST("/auth/evaluate_permission")) {
+            handler.evaluatePermission(it).flatMap{ r ->
+                ServerResponse.ok().bodyValue(r)
+            }
+            .onErrorResume(WebClientResponseException::class.java) { e ->
+                ServerResponse
+                    .status(e.statusCode)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(e.responseBodyAsString)
+            }.onErrorResume(InvalidDataException::class.java) { e ->
+                ServerResponse
+                    .status(400)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(mapOf("error" to e.message))
+            }
+        }
 }
 
 @Component
@@ -119,6 +157,7 @@ class AuthHandler(private val service: AuthService) {
     fun login(request: ServerRequest) = request.bodyToMono(LoginDTO::class.java).flatMap { u -> service.login(u) }
     fun refreshToken(request: ServerRequest) = request.bodyToMono(RefreshTokenDTO::class.java).flatMap { u -> service.refreshToken(u) }
     fun certs(request: ServerRequest) = service.certs()
+    fun evaluatePermission(request: ServerRequest) = request.bodyToMono(EvaluatePermissionDTO::class.java).flatMap { u -> service.evaluatePermission(u) }
 }
 
 @Service
@@ -126,4 +165,5 @@ class AuthService(private val keycloakClient: KeycloakClient) {
     fun login(dto: LoginDTO): Mono<TokenDTO> = keycloakClient.login(dto.username, dto.password)
     fun refreshToken(dto: RefreshTokenDTO): Mono<TokenDTO> = keycloakClient.refreshToken(dto.refresh_token)
     fun certs(): Mono<Any> = keycloakClient.certs()
+    fun evaluatePermission(dto: EvaluatePermissionDTO): Mono<Any> = keycloakClient.evaluatePermission(dto.userToken, dto.resource, dto.scope)
 }

--- a/src/main/kotlin/com/pucrs/construcaosoftware/api/AuthController.kt
+++ b/src/main/kotlin/com/pucrs/construcaosoftware/api/AuthController.kt
@@ -28,13 +28,14 @@ import org.springframework.http.MediaType
 class AuthController {
     @RouterOperations(
         RouterOperation(
-            path = "/login",
+            path = "/auth/login",
             method = arrayOf(RequestMethod.POST),
             beanClass = AuthHandler::class,
             beanMethod = "login",
             operation = Operation(
                 operationId = "create",
                 method = "POST",
+                summary = "Login",
                 requestBody = RequestBody(
                     required = true,
                     content = arrayOf(
@@ -46,13 +47,14 @@ class AuthController {
             ),
         ),
         RouterOperation(
-            path = "/refresh_token",
+            path = "/auth/refresh_token",
             method = arrayOf(RequestMethod.POST),
             beanClass = AuthHandler::class,
             beanMethod = "refreshToken",
             operation = Operation(
                 operationId = "refreshToken",
                 method = "POST",
+                summary = "Informe o refresh_token obtido no login para obter um novo token",
                 requestBody = RequestBody(
                     required = true,
                     content = arrayOf(
@@ -64,19 +66,20 @@ class AuthController {
             ),
         ),
         RouterOperation(
-            path = "/certs",
+            path = "/auth/certs",
             method = arrayOf(RequestMethod.GET),
             beanClass = AuthHandler::class,
             beanMethod = "certs",
             operation = Operation(
                 operationId = "certs",
-                method = "GET"
+                method = "GET",
+                summary = "Recupera as chaves públicas do servidor, no formato JWK, para validação dos tokens",
             ),
         ),
     )
   @Bean
   fun authRoutes(handler: AuthHandler): RouterFunction<ServerResponse> =
-    RouterFunctions.route(RequestPredicates.POST("/login")) {
+    RouterFunctions.route(RequestPredicates.POST("/auth/login")) {
         handler.login(it).flatMap{ r ->
           ServerResponse.ok().bodyValue(r)
         }
@@ -87,7 +90,7 @@ class AuthController {
                 .bodyValue(e.responseBodyAsString)
         }
     }
-        .andRoute(RequestPredicates.POST("/refresh_token")) {
+        .andRoute(RequestPredicates.POST("/auth/refresh_token")) {
             handler.refreshToken(it).flatMap{ r ->
                 ServerResponse.ok().bodyValue(r)
             }
@@ -98,7 +101,7 @@ class AuthController {
                     .bodyValue(e.responseBodyAsString)
             }
         }
-        .andRoute(RequestPredicates.GET("/certs")) {
+        .andRoute(RequestPredicates.GET("/auth/certs")) {
             handler.certs(it).flatMap{ r ->
                 ServerResponse.ok().bodyValue(r)
             }

--- a/src/main/kotlin/com/pucrs/construcaosoftware/api/UsersController.kt
+++ b/src/main/kotlin/com/pucrs/construcaosoftware/api/UsersController.kt
@@ -38,6 +38,7 @@ class UsersController {
             operation = Operation(
                 operationId = "create",
                 method = "POST",
+                summary = "Cria um novo usuário",
                 security = [SecurityRequirement(name = "Keycloak access-token")],
                 requestBody = RequestBody(
                     required = true,
@@ -60,6 +61,7 @@ class UsersController {
             operation = Operation(
                 operationId = "list",
                 method = "GET",
+                summary = "Lista todos os usuários",
                 security = [SecurityRequirement(name = "Keycloak access-token")],
             ),
             produces = arrayOf("application/json")
@@ -72,6 +74,7 @@ class UsersController {
             operation = Operation(
                 operationId = "get",
                 method = "GET",
+                summary = "Recupera um usuário pelo ID",
                 security = [SecurityRequirement(name = "Keycloak access-token")],
                 parameters = [Parameter(
                     name = "id",
@@ -91,6 +94,7 @@ class UsersController {
             operation = Operation(
                 operationId = "update",
                 method = "PUT",
+                summary = "Atualiza um usuário pelo ID",
                 security = [SecurityRequirement(name = "Keycloak access-token")],
                 requestBody = RequestBody(
                     required = true,
@@ -121,6 +125,7 @@ class UsersController {
             operation = Operation(
                 operationId = "updatePassword",
                 method = "PATCH",
+                summary = "Atualiza a senha do usuário",
                 security = [SecurityRequirement(name = "Keycloak access-token")],
                 requestBody = RequestBody(
                     required = true,
@@ -151,6 +156,7 @@ class UsersController {
             operation = Operation(
                 operationId = "delete",
                 method = "DELETE",
+                summary = "Exclui um usuário pelo ID",
                 security = [SecurityRequirement(name = "Keycloak access-token")],
                 parameters = [Parameter(
                     name = "id",

--- a/src/main/kotlin/com/pucrs/construcaosoftware/dto/Dto.kt
+++ b/src/main/kotlin/com/pucrs/construcaosoftware/dto/Dto.kt
@@ -38,3 +38,9 @@ data class LoginDTO(
   val username: String,
   val password: String,
 )
+
+data class EvaluatePermissionDTO(
+    val userToken: String,
+    val resource: String,
+    val scope: String,
+)

--- a/src/main/kotlin/com/pucrs/construcaosoftware/exceptions/Exceptions.kt
+++ b/src/main/kotlin/com/pucrs/construcaosoftware/exceptions/Exceptions.kt
@@ -1,0 +1,3 @@
+package com.pucrs.construcaosoftware.exceptions
+
+class InvalidDataException(message: String) : Exception(message)

--- a/src/main/kotlin/com/pucrs/construcaosoftware/keycloak/KeycloakClient.kt
+++ b/src/main/kotlin/com/pucrs/construcaosoftware/keycloak/KeycloakClient.kt
@@ -60,6 +60,15 @@ class KeycloakClient(
         return responseSpec.bodyToMono(TokenDTO::class.java)
     }
 
+    fun certs(): Mono<Any> {
+        val webClient = WebClient.create(baseUrl)
+        val spec = webClient.get()
+        val bodySpec = spec.uri("/realms/${realm}/protocol/openid-connect/certs")
+        val responseSpec = bodySpec.retrieve()
+
+        return responseSpec.bodyToMono(Any::class.java)
+    }
+
     fun create(user: UserCreateDTO): Mono<UserDTO> {
         val realmResource = keycloak.realm(realm)
 

--- a/src/main/kotlin/com/pucrs/construcaosoftware/keycloak/KeycloakClient.kt
+++ b/src/main/kotlin/com/pucrs/construcaosoftware/keycloak/KeycloakClient.kt
@@ -1,6 +1,9 @@
 package com.pucrs.construcaosoftware.keycloak
 
 import com.pucrs.construcaosoftware.dto.*
+import com.pucrs.construcaosoftware.exceptions.InvalidDataException
+import org.apache.http.HttpStatus
+import javax.ws.rs.NotFoundException
 import org.keycloak.admin.client.CreatedResponseUtil
 import org.keycloak.admin.client.Keycloak
 import org.keycloak.representations.idm.CredentialRepresentation
@@ -10,23 +13,23 @@ import org.springframework.stereotype.Component
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.reactive.function.BodyInserters
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
-import javax.ws.rs.NotFoundException
 
 @Component
 class KeycloakClient(
-    private val keycloak: Keycloak,
-    @Value("\${keycloak.realm}") private val realm: String,
-    @Value("\${keycloak.roles}") private val roles: List<String>,
-    @Value("\${keycloak.base}") private val baseUrl: String,
-    @Value("\${keycloak.client-id}") private val clientId: String,
-    @Value("\${keycloak.client-secret}") private val clientSecret: String
+        private val keycloak: Keycloak,
+        @Value("\${keycloak.realm}") private val realm: String,
+        @Value("\${keycloak.roles}") private val roles: List<String>,
+        @Value("\${keycloak.base}") private val baseUrl: String,
+        @Value("\${keycloak.client-id}") private val clientId: String,
+        @Value("\${keycloak.client-secret}") private val clientSecret: String
 ) {
 
     fun login(
-        username: String,
-        password: String,
+            username: String,
+            password: String,
     ): Mono<TokenDTO> {
         val formData = LinkedMultiValueMap<String, String>()
         formData.add("grant_type", "password")
@@ -58,6 +61,39 @@ class KeycloakClient(
         val responseSpec = headersSpec.retrieve()
 
         return responseSpec.bodyToMono(TokenDTO::class.java)
+    }
+
+    fun evaluatePermission(userToken: String, resource: String, scope: String): Mono<Any> {
+        if (resource.isEmpty()) {
+            throw InvalidDataException("Invalid resource")
+        }
+        if (scope.isEmpty() || scope.contains(",")) {
+            throw InvalidDataException("Invalid scope")
+        }
+
+        val formData = LinkedMultiValueMap<String, String>()
+        formData.add("grant_type", "urn:ietf:params:oauth:grant-type:uma-ticket")
+        formData.add("client_id", clientId)
+        formData.add("client_secret", clientSecret)
+        formData.add("audience", clientId)
+        formData.add("response_mode", "decision")
+        formData.add("permission", "${resource}#${scope}")
+        formData.add("subject_token", userToken)
+
+        val webClient = WebClient.create(baseUrl)
+        val spec = webClient.post()
+        val bodySpec = spec.uri("/realms/${realm}/protocol/openid-connect/token")
+        val headersSpec = bodySpec.body(BodyInserters.fromFormData(formData))
+        val responseSpec = headersSpec.retrieve()
+
+        return responseSpec.bodyToMono(Any::class.java)
+            // .onErrorResume(WebClientResponseException::class.java) {
+            //     if (it.rawStatusCode == 403) {
+            //         Mono.just(mapOf("result" to false))
+            //     } else {
+            //         Mono.error(it)
+            //     }
+            // }
     }
 
     fun certs(): Mono<Any> {
@@ -94,28 +130,34 @@ class KeycloakClient(
         return Mono.just(UserDTO(userId, user.username, user.role, user.email))
     }
 
-    fun list(): Flux<UserDTO> = Flux.fromIterable(
-        roles.flatMap { role ->
-            keycloak.realm(realm).roles().get(role).roleUserMembers.map {
-                UserDTO(it.id, it.username, role, it.email)
-            }
-        }
-    )
+    fun list(): Flux<UserDTO> =
+            Flux.fromIterable(
+                    roles.flatMap { role ->
+                        keycloak.realm(realm).roles().get(role).roleUserMembers.map {
+                            UserDTO(it.id, it.username, role, it.email)
+                        }
+                    }
+            )
 
     fun get(id: String): Mono<UserDTO> {
         val user = keycloak.realm(realm).users().get(id)
 
         return Mono.fromCallable {
             val userRepresentation = user.toRepresentation()
-            val role = user.roles().realmLevel().listAll().filter { roles.contains(it.name) }.firstOrNull()
+            val role =
+                    user.roles()
+                            .realmLevel()
+                            .listAll()
+                            .filter { roles.contains(it.name) }
+                            .firstOrNull()
             UserDTO(
-                userRepresentation.id,
-                userRepresentation.username,
-                role?.name,
-                userRepresentation.email
+                    userRepresentation.id,
+                    userRepresentation.username,
+                    role?.name,
+                    userRepresentation.email
             )
         }
-            .onErrorResume (NotFoundException::class.java) { Mono.empty() }
+                .onErrorResume(NotFoundException::class.java) { Mono.empty() }
     }
 
     fun update(id: String, dto: UserUpdateDTO): Mono<UserDTO> {
@@ -152,5 +194,6 @@ class KeycloakClient(
     }
 
     fun delete(id: String): Mono<SuccessDTO> =
-        Mono.fromCallable { keycloak.realm(realm).users().delete(id) }.then(Mono.just(SuccessDTO(true)))
+            Mono.fromCallable { keycloak.realm(realm).users().delete(id) }
+                    .then(Mono.just(SuccessDTO(true)))
 }


### PR DESCRIPTION
Criada rota `/certs`, para recuperação das chaves públicas do Keycloak. Necessário para validar os tokens nos microsserviços.

Rotas do AuthController movidas para /auth:

- `/auth/login`
- `/auth/refresh_token`
- `/auth/certs`

Documentação OpenAPI atualizada com descrições das rotas.

Criada rota de verificação de permissões, que consulta o Keycloak conforme documentado em https://www.keycloak.org/docs/latest/authorization_services/#_service_obtaining_permissions.
